### PR TITLE
Getting ready for melpa

### DIFF
--- a/vim-modeline.el
+++ b/vim-modeline.el
@@ -225,6 +225,7 @@ Otherwise this function returns nil."
                                                         (car input))))))))
     (vim-modeline/parse-options result)))
 
+;;;###autoload
 (defun vim-modeline/do ()
   (let ((options (vim-modeline/get)))
     (dolist (opt options)

--- a/vim-modeline.el
+++ b/vim-modeline.el
@@ -23,6 +23,10 @@
 ;; VIM (includes vi and ex) uses its own per-file configuration called
 ;; 'modeline', which is almost similar to the file local variables in Emacs.
 
+;; To enable this package after loading it, add `vim-modeline/do' to
+;; `find-file-hook':
+
+;;   (add-to-list 'find-file-hook 'vim-modeline/do)
 
 ;;; Code:
 

--- a/vim-modeline.el
+++ b/vim-modeline.el
@@ -28,11 +28,16 @@
 
 (eval-when-compile (require 'cl))
 
-(defvar vim-modeline/modelines 5
-  "Default number of lines for searching modelines in the
-  beginning of the buffer, and the end of the buffer.")
+(defgroup vim-modeline nil
+  "Facilities for setting file options based on vim modeline.")
 
-(defvar vim-modeline/options-alist
+(defcustom vim-modeline/modelines 5
+  "Default number of lines for searching modelines in the
+  beginning of the buffer, and the end of the buffer."
+  :type 'integer
+  :group 'vim-modeline)
+
+(defcustom vim-modeline/options-alist
   '(("shiftwidth" . vim-modeline/shiftwidth)
     ("sw" . vim-modeline/shiftwidth)
     ("textwidth" . vim-modeline/textwidth)
@@ -49,7 +54,9 @@
     ("et" . vim-modeline/expandtab)
     ("noexpandtab" . vim-modeline/expandtab)
     ("noet" . vim-modeline/expandtab))
-  "Alist of VIM option names and handlers")
+  "Alist of VIM option names and handlers"
+  :type '(alist :key-type (string :tag "Option") :value-type (function :tag "Handler function"))
+  :group 'vim-modeline)
 
 ;;;
 ;;; From the VIM help messages


### PR DESCRIPTION
I made a few tweaks to make the ready to be packaged. Specifically, I converted the variable declarations to use `defcustom` so they can be edited through `M-x customize`, and I added an autoload cookie to `vim-modeline/do`, which I believe is the main entry point for this package.

Users will still have to add the function to `find-file-hooks`, but this is now documented in the commentary, so that users who install the file through MELPA or similar facilities and who don't have the readme file will still know what to do.

Fixes #2.